### PR TITLE
chore(Upgrade): Upgrading django from Django 1.10 to Django 2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10
+Django==2.1
 django-cors-middleware==1.2.0
 django-extensions==1.7.1
 djangorestframework==3.4.4


### PR DESCRIPTION
**What does this PR do?**
- Upgrades the Django app from Django 1.10 to Django 2.1

**Description of Task to be completed?**
 - Ensure the app is running on a Django 2.1 upgrade,
 so that the new instalment packages can work effectively.

**What are the relevant pivotal tracker stories?**
 - #164069205

@wasibani-roy  @marthamareal @joelethan @Peace-Apple @CryceTruly