### PR TITLE
#164069219 Enable user reset password.

### DIFF
--- a/authors/apps/authentication/tests/test_base.py
+++ b/authors/apps/authentication/tests/test_base.py
@@ -14,3 +14,5 @@ class BaseTest(APITestCase):
         self.registration_url = reverse('authentication:registration')
         self.viewusers = reverse('authentication:viewusers')
         self.verify_url = reverse('authentication:verify_email')
+        self.reset_password_url = reverse('authentication:reset_password_link')
+        self.change_password_url = reverse('authentication:change_password')

--- a/authors/apps/authentication/tests/test_reset_password.py
+++ b/authors/apps/authentication/tests/test_reset_password.py
@@ -1,0 +1,107 @@
+"""Reset Password tests."""
+import jwt
+from .test_base import BaseTest
+from rest_framework.views import status
+from .test_data import valid_user
+from django.conf import settings
+
+
+class ResetPasswordTest(BaseTest):
+
+    def test_existing_email(self):
+        """Tests if user email exists in the database."""
+        response = self.client.post(
+            self.reset_password_url, {"email": "joel@gmail.com"}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data['detail'], "Not found.")
+
+    def test_send_password_link(self):
+        """Tests if a reset password link is sent successfully."""
+        self.client.post(self.registration_url, valid_user, format='json')
+        response = self.client.post(
+            self.reset_password_url,
+            {"email": "bagendadeogracious@gmail.com"},
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['message'],
+            "Please check your email for the reset password link."
+        )
+
+    def test_email_key_error(self):
+        """Tests if a user has a provided an email field."""
+        self.client.post(self.registration_url, valid_user, format='json')
+        response = self.client.post(
+            self.reset_password_url,
+            {"eml": "bagendadeogracious@gmail.com"},
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['errors'][0],
+            "Email is required in order to reset password."
+        )
+
+    def test_password_error(self):
+        """Tests if a user has a provided a wrong password."""
+        token = str((jwt.encode({
+            "email": "bagendadeogracious@gmail.com"},
+            settings.SECRET_KEY)).decode('utf-8')
+        )
+        self.client.post(self.registration_url, valid_user, format='json')
+        response = self.client.patch(
+            self.change_password_url+"?token="+token,
+            {"password": "bag"},
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'],
+                         "password should be atleast 8 characters.")
+
+    def test_successful_password_change(self):
+        """Tests if a user has changed the password successfully."""
+        token = str((jwt.encode(
+            {"email": "bagendadeogracious@gmail.com"}, settings.SECRET_KEY)).decode('utf-8'))
+        self.client.post(self.registration_url, valid_user, format='json')
+        response = self.client.patch(
+            self.change_password_url+"?token="+token,
+            {"password": "bagenda1234"},
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['message'],
+            "you have reset your password successfully."
+        )
+
+    def test_wrong_token(self):
+        """Tests if a user has provided a wrong token."""
+        token = str((jwt.encode(
+            {"email": "bagendadeogracious@gmail.com"},
+            settings.SECRET_KEY)).decode('utf-8')
+        )
+        self.client.post(self.registration_url, valid_user, format='json')
+        response = self.client.patch(
+            self.change_password_url+"?token="+token+"wrong",
+            {"password": "bagenda1234"},
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'],
+                         "verification link is invalid.")
+
+    def test_password_change_provided(self):
+        """Tests if a user has provided a password."""
+        token = str((jwt.encode(
+            {"email": "bagendadeogracious@gmail.com"}, 
+            settings.SECRET_KEY)).decode('utf-8')
+        )
+        self.client.post(self.registration_url, valid_user, format='json')
+        response = self.client.patch(
+            self.change_password_url+"?token="+token, {"pwd": "bagenda1234"},
+            format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['errors']
+                         [0], "Password feild is required.")

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -2,10 +2,20 @@ from django.urls import path
 
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView,
-    EmailVerifyAPIView)
+    EmailVerifyAPIView, PasswordResetAPIView, ChangePasswordAPIView)
 urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view(), name='viewusers'),
     path('users/', RegistrationAPIView.as_view(), name='registration'),
     path('users/login/', LoginAPIView.as_view(), name='login'),
     path('users/verify/', EmailVerifyAPIView.as_view(), name='verify_email'),
+    path(
+        'users/reset-password/',
+        PasswordResetAPIView.as_view(),
+        name='reset_password_link'
+    ),
+    path(
+        'users/reset-password/change/',
+        ChangePasswordAPIView.as_view(),
+        name='change_password'
+    )
 ]

--- a/authors/apps/core/utils.py
+++ b/authors/apps/core/utils.py
@@ -1,0 +1,19 @@
+from django.contrib.sites.shortcuts import get_current_site
+from django.core.mail import EmailMessage
+
+
+class Utilities:
+    """Utility class that contains helper function"""
+
+    @staticmethod
+    def email_renderer(data):
+        """This function sends email to users."""
+
+        url = f"http://{get_current_site(data[0]).domain}\
+            /api/users/{data[1]}?token={data[2]}"
+        subject = f"[Authors Heaven] {data[3]}"
+        body = f"Hello, \
+                \nYou are receiving this e-mail because you have {data[4]}' \
+                 '\nClick the click below to verify your account.\n{url}"
+        EmailMessage(subject, body, to=[data[5]]).send(fail_silently=False)
+        return


### PR DESCRIPTION
#### What does this PR do?
- This PR enables a user to reset their password
#### Description of Task to be completed?
- Send a reset password link via email
- Enable a user to reset password
#### How should this be manually tested?
- Make sure PostgreSQL is installed and create a database.
- Clone the repo, cd into `Ah-backend-aquaman` and checkout the branch `ft-reset-password-164069219`
    -  pip install -r requirements.txt
    -  python manage.py makemmigrations
    -  python manage.py migrate
    -  python manage.py runserver
- Use these endpoints to reset password:
    -  Password Link
       `http://127.0.0.1:8000/api/users/reset-password/`
        Then check your email for reset password link
    -  Password Change
       `http://127.0.0.1:8000/api/users/reset-password/change/`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- [#164069219](https://www.pivotaltracker.com/story/show/164069219)

#### Screen shots

* The user navigates to the `http://127.0.0.1:8000/api/users/reset-password/` and sends a valid email

<img width="1144" alt="Screenshot 2019-03-11 at 12 43 12" src="https://user-images.githubusercontent.com/19649761/54115255-31097100-43fd-11e9-982e-5185eeab3b46.png">

* The user goes to email and clicks on reset password link

<img width="1144" alt="Screenshot 2019-03-11 at 12 46 01" src="https://user-images.githubusercontent.com/19649761/54115363-572f1100-43fd-11e9-9a9c-8cf04dd73b1f.png">

* The user follows that link and then he/she provides their password

<img width="1144" alt="Screenshot 2019-03-11 at 12 44 15" src="https://user-images.githubusercontent.com/19649761/54115439-7c238400-43fd-11e9-854a-33f976b64a80.png">

