### PR TITLE
#164069231 List Users functionality

### DIFF
--- a/authors/apps/authentication/renderers.py
+++ b/authors/apps/authentication/renderers.py
@@ -12,6 +12,9 @@ class UserJSONRenderer(JSONRenderer):
         # the default JSONRenderer to handle rendering errors, so we need to
         # check for this case.
         errors = ''
+        response = json.dumps({'user': data})
+        if isinstance(data, list):
+            return json.dumps({'authorslist': data})
         try:
             errors = data.get('errors', None)
         except:
@@ -23,6 +26,4 @@ class UserJSONRenderer(JSONRenderer):
             return super(UserJSONRenderer, self).render(data)
 
         # Finally, we can render our data under the "user" namespace.
-        return json.dumps({
-            'user': data
-        })
+        return response

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -4,6 +4,7 @@ from django.contrib.auth import authenticate
 
 from rest_framework import serializers
 
+from authors.apps.profiles.serializers import ProfileSerializer
 from .models import User
 
 from .validators import validate_email
@@ -140,6 +141,7 @@ class UserSerializer(serializers.ModelSerializer):
     # characters. These values are the default provided by Django. We could
     # change them, but that would create extra work while introducing no real
     # benefit, so let's just stick with the defaults.
+    profile = ProfileSerializer(many=False, read_only=True, required=False)
     password = serializers.CharField(
         max_length=128,
         min_length=8,
@@ -148,7 +150,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('email', 'username', 'password')
+        fields = ('email', 'username', 'password', 'profile', )
 
         # The `read_only_fields` option is an alternative for explicitly
         # specifying the field with `read_only=True` like we did for password

--- a/authors/apps/profiles/tests/test_data.py
+++ b/authors/apps/profiles/tests/test_data.py
@@ -19,4 +19,3 @@ update_profile = {
         "bio": "everything tech",
         "image": "https://localhost:8000/people.png"
 }
-

--- a/authors/apps/profiles/tests/test_profile.py
+++ b/authors/apps/profiles/tests/test_profile.py
@@ -44,3 +44,42 @@ class TestProfile(BaseTestCase):
 		url = reverse('profiles:update_profile', kwargs={'username': 'testuser12'})
 		response = self.client.put(url, update_profile, format='json')
 		self.assertEquals(response.status_code, 403)
+
+	def test_authorized_get_authors_list(self):
+		"""Test an authorised user getting authors list showing profiles of existing authors """
+		self.authorize_user()
+		url = reverse('profiles:authors_list')
+		response = self.client.get(url)
+		self.assertEquals(response.status_code, 200)
+
+	def test_unauthorized_get_authors_list(self):
+		"""Test an unauthorised user getting authors list showing profiles of existing authors """
+		url = reverse('profiles:authors_list')
+		response = self.client.get(url)
+		self.assertEquals(response.status_code, 403)
+
+	def test_authorized_user_using_wrong_request_method_to_get_authors_list(self):
+		"""Test authorized user getting authors list using wrong request method"""
+		self.authorize_user()
+		url = reverse('profiles:authors_list')
+		response = self.client.post(url)
+		self.assertEquals(response.status_code, 405)
+
+	def test_unauthorized_user_using_wrong_request_method_to_get_authors_list(self):
+		"""Test unauthorized user getting authors list using wrong request method"""
+		url = reverse('profiles:authors_list')
+		response = self.client.post(url)
+		self.assertEquals(response.status_code, 403)
+
+	def test_correct_authors_list_data_is_returned(self):
+		"""Test the correct data that is returned in the authors list"""
+		self.authorize_user()
+		url = reverse('profiles:authors_list')
+		response = self.client.get(url)
+		self.assertEquals(response.data[0]['email'], 'testuser@gmail.com')
+		self.assertEquals(response.data[0]['username'], 'testuser12')
+		self.assertIn('email', response.data[0]['profile'])
+		self.assertIn('username', response.data[0]['profile'])
+		self.assertIn('image', response.data[0]['profile'])
+		self.assertIn('bio', response.data[0]['profile'])
+		self.assertEquals(response.status_code, 200)

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
 from .views import (ProfileRetrieveAPIView,
-                    ListAuthorsAPIView, ProfileUpdateAPIView)
+                    ListAuthorsAPIView, ProfileUpdateAPIView, AuthorsAPIView)
 
 urlpatterns = [
     path('profiles/<username>', ProfileRetrieveAPIView.as_view(), name="get_profile"),
     path('profiles/<username>/edit',
          ProfileUpdateAPIView.as_view(), name="update_profile"),
     path('profiles/', ListAuthorsAPIView.as_view(), name="users_profiles"),
+    path('authorslist/', AuthorsAPIView.as_view(), name="authors_list"),
+
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -1,6 +1,9 @@
 from rest_framework import generics, permissions, serializers, status
 from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
+from authors.apps.authentication.models import User
+from authors.apps.authentication.renderers import UserJSONRenderer
+from authors.apps.authentication.serializers import UserSerializer
 
 from .models import Profile
 from .permissions import IsOwnerOrReadOnly
@@ -31,16 +34,6 @@ class ProfileRetrieveAPIView(generics.RetrieveAPIView):
         return Response(profile, status=status.HTTP_200_OK)
 
 
-class ListAuthorsAPIView(generics.ListAPIView):
-    """
-    Implements listing of all users' profiles
-    """
-    queryset = Profile.objects.all()
-    serializer_class = ProfileSerializer
-    renderer_classes = (ProfileJSONRenderer, )
-    permission_classes = (permissions.IsAuthenticated, )
-
-
 class ProfileUpdateAPIView(generics.UpdateAPIView):
     """ Allows the currently logged in user
     to edit their user profile
@@ -52,3 +45,25 @@ class ProfileUpdateAPIView(generics.UpdateAPIView):
         username = self.kwargs.get("username")
         obj = get_object_or_404(Profile, user__username=username)
         return obj
+
+
+class ListView(generics.ListAPIView):
+    permission_classes = (permissions.IsAuthenticated, )
+
+
+class ListAuthorsAPIView(ListView):
+    """
+    Implements listing of all users' profiles
+    """
+    queryset = Profile.objects.all()
+    serializer_class = ProfileSerializer
+    renderer_classes = (ProfileJSONRenderer,)
+
+
+class AuthorsAPIView(ListView):
+    """
+    Displays a list of existing authors with their profiles.
+    """
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    renderer_classes = (UserJSONRenderer,)


### PR DESCRIPTION
## What does this PR do?
This PR adds a feature that enables a user to view the list and profiles of existing authors however they are not able to edit these profiles.

## How should this be manually tested?
- Clone this repository
- cd into the directory Ah-backend-aquaman
- Checkout the branch ft-list-users-functionality-164069231
- Create and activate your virtual environment
- pip install -r requirements.txt
- python manage.py makemmigrations
- python manage.py migrate
- Source your .env file
- python manage.py runserver
- Sign up, verify your email and login
- Then navigate to the endpoint `http://127.0.0.1:8000/api/authorslist/`

## What are the relevant pivotal tracker stories?
[#164069231](https://www.pivotaltracker.com/story/show/164069231)

## Screenshots
After creating your account, verifying your account and logging in, copy the token and paste it into the token field

![image](https://user-images.githubusercontent.com/42435346/54219449-972aec80-4500-11e9-9980-72034c5e68d0.png)

Once you send the request, you should be able to see the list and profiles of existing authors

![image](https://user-images.githubusercontent.com/42435346/54219519-ba559c00-4500-11e9-9b21-975571a9f579.png)
