### PR TITLE
#164596392 Fix verify social auth users and return their object

### DIFF
--- a/authors/apps/social_auth/register.py
+++ b/authors/apps/social_auth/register.py
@@ -17,5 +17,13 @@ def register_social_user(provider, user_id, email, name):
         user = {
             'username': name, 'email': email, 'password': 'XXXXXXXX'}
         User.objects.create_user(**user)
+
+        user = User.objects.filter(email=email).first()
+        user.is_verified = True
+        user.save()
+
         new_user = authenticate(email=email, password="XXXXXXXX")
-        return new_user.token
+        return {
+            'username': new_user.username,
+            'email': new_user.email,
+            'token': new_user.token}


### PR DESCRIPTION
#### What does this PR do?
- This PR verifies the users who register using social authentication
- This PR returns the object of the user upon successful registration
#### Description of Task to be completed?
- Users are able to access all protected endpoints.
- An object of the user is returned after registration
#### How should this be manually tested?
- Clone the repo, cd into `Ah-backend-aquaman` and checkout the branch `bg-fix-verify-social-auth-users-164596392`
    -  pip install -r requirements.txt
    -  python manage.py makemmigrations
    -  python manage.py migrate
    -  python manage.py runserver
- Use these endpoints to log in with:
    -  Facebook
       `POST http://127.0.0.1:8000/api/social/auth/facebook/`
    -  Google
       `POST http://127.0.0.1:8000/api/social/auth/google/`
    - Twitter
       `POST http://127.0.0.1:8000/api/social/auth/twitter/`
#### What are the relevant pivotal tracker stories?
- [#164596392](https://www.pivotaltracker.com/story/show/164596392)

#### Screenshots (if appropriate)
    -  Google
<img width="1436" alt="Screenshot 2019-03-12 at 22 44 57" src="https://user-images.githubusercontent.com/6951438/54230946-91410580-4518-11e9-800c-e6611be6e843.png">

    -  Facebook

<img width="1436" alt="Screenshot 2019-03-12 at 22 46 42" src="https://user-images.githubusercontent.com/6951438/54231050-cf3e2980-4518-11e9-90ee-9f3f4f725830.png">

    -  Twitter

<img width="1436" alt="Screenshot 2019-03-12 at 22 48 39" src="https://user-images.githubusercontent.com/6951438/54231158-03b1e580-4519-11e9-846d-dbeba5c00f20.png">


