### PR TITLE
#164069228 favourite an article

### DIFF
--- a/authors/apps/articles/migrations/0001_initial.py
+++ b/authors/apps/articles/migrations/0001_initial.py
@@ -31,7 +31,10 @@ class Migration(migrations.Migration):
                 ('image', models.URLField(blank=True)),
                 ('user_rating', models.CharField(default='0', max_length=10)),
                 ('tagList', django.contrib.postgres.fields.ArrayField(base_field=models.CharField(max_length=200), blank=True, default=list, size=None)),
+                ('favorited', models.BooleanField(default=False)),
+                ('favoritesCount', models.IntegerField(default=0)),
                 ('author', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='profiles.Profile')),
+                ('favorites', models.ManyToManyField(blank=True, related_name='favorited_articles', to='profiles.Profile')),
             ],
             options={
                 'ordering': ['-created_at'],

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -10,6 +10,7 @@ class ArticleSerializer (serializers.ModelSerializer):
     user_rating = serializers.CharField(
         source="average_rating", required=False)
     read_time = serializers.CharField(max_length=100, read_only=True)
+    favorites = serializers.SerializerMethodField()
 
     class Meta:
         model = Article
@@ -28,6 +29,9 @@ class ArticleSerializer (serializers.ModelSerializer):
             "dislikes",
             "user_rating",
             "read_time",
+            "favorited",
+            "favorites",
+            "favoritesCount"
         )
         read_only_fields = (
             'author',
@@ -37,6 +41,12 @@ class ArticleSerializer (serializers.ModelSerializer):
             'user_rating',
         )
 
+    def get_favorites(self, obj):
+        user_profile = obj.favorites.all()
+        user_favorites = []
+        for profile in user_profile:
+            user_favorites.append(profile.user.username)
+        return user_favorites
 
 class ArticleLikeDislikeSerializer(serializers.ModelSerializer):
 
@@ -54,11 +64,14 @@ class ArticleLikeDislikeSerializer(serializers.ModelSerializer):
             'user': {'write_only': True},
             'article': {'write_only': True},
         }
+
+
 class RatingSerializer(serializers.ModelSerializer):
     article = serializers.SerializerMethodField()
     rated_by = serializers.SerializerMethodField()
     author = serializers.SerializerMethodField()
-    score = serializers.DecimalField(required=True, max_digits=5, decimal_places=2)
+    score = serializers.DecimalField(
+        required=True, max_digits=5, decimal_places=2)
 
     class Meta:
         model = Rating
@@ -72,4 +85,3 @@ class RatingSerializer(serializers.ModelSerializer):
 
     def get_rated_by(self, obj):
         return obj.rated_by.username
-

--- a/authors/apps/articles/tests/test_favorite.py
+++ b/authors/apps/articles/tests/test_favorite.py
@@ -1,0 +1,81 @@
+"""
+test module for rating an article
+"""
+from django.urls import reverse
+from authors.apps.articles.tests.base_class import ArticlesBaseTest
+from ..models import Article
+
+
+class TestRatingArticle(ArticlesBaseTest):
+    """
+    test class to contain functions to test rating an article
+    """
+
+    def setUp(self):
+        super().setUp()
+
+    def test_favorite_your_own_article(self):
+        """
+        method to test favorating your own article
+        """
+        self.add_article()
+        article = Article.objects.all().first()
+        response = self.client.post(
+            reverse("articles:article-favorite", kwargs={'slug': article.slug})
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("article", response.json())
+
+    def test_rate_someones_article(self):
+        """
+        method to test favorating someone's article
+        """
+        self.add_article()
+        article = Article.objects.all().first()
+        self.register_and_login_new_user()
+        response = self.client.post(
+            reverse("articles:article-favorite", kwargs={'slug': article.slug})
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertIn("article", response.json())
+
+    def test_favorite_non_existant_article(self):
+        """
+        method to test favorite non existant article
+        """
+        self.add_article()
+        self.register_and_login_new_user()
+        response = self.client.post(
+            reverse("articles:article-favorite", kwargs={'slug': "play-chess"})
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("article", response.json())
+
+    def test_unfavorite_an_article(self):
+        """
+        method to test unfavorating an article
+        """
+        self.add_article()
+        article = Article.objects.all().first()
+        self.register_and_login_new_user()
+        self.client.post(
+            reverse("articles:article-favorite", kwargs={'slug': article.slug})
+        )
+        response = self.client.delete(
+            reverse("articles:article-favorite", kwargs={'slug': article.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("article", response.json())
+
+    def test_unfavorite_article_not_in_your_favorites(self):
+        """
+        method to test unfavorating an article not in your favorites
+        """
+        self.add_article()
+        article = Article.objects.all().first()
+        self.register_and_login_new_user()
+        response = self.client.delete(
+            reverse("articles:article-favorite", kwargs={'slug': article.slug})
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("article", response.json())

--- a/authors/apps/articles/tests/test_rating_article.py
+++ b/authors/apps/articles/tests/test_rating_article.py
@@ -26,8 +26,9 @@ class TestRatingArticle(ArticlesBaseTest):
             data={"article": {"score": 3}},
             format="json"
         )
+        data = response.data
         self.assertEqual(response.status_code, 403)
-        self.assertIn("article", response.json())
+        self.assertIn("You can not rate your own article", data["message"])
 
     def test_rate_someones_article(self):
         """
@@ -41,8 +42,9 @@ class TestRatingArticle(ArticlesBaseTest):
             data={"article": {"score": 3}},
             format="json"
         )
+        data = response.data
         self.assertEqual(response.status_code, 201)
-        self.assertIn("article", response.json())
+        self.assertIn("score", data)
 
     def test_rate_out_of_range(self):
         """
@@ -56,8 +58,9 @@ class TestRatingArticle(ArticlesBaseTest):
             data={"article": {"score": 6}},
             format="json"
         )
+        data = response.data
         self.assertEqual(response.status_code, 400)
-        self.assertIn("article", response.json())
+        self.assertIn("Rating must be between 0 and 5", data["message"])
 
     def test_rate_article_not_found(self):
         """
@@ -71,7 +74,7 @@ class TestRatingArticle(ArticlesBaseTest):
             format="json"
         )
         self.assertEqual(response.status_code, 404)
-        self.assertIn("article", response.json())
+        self.assertIn("detail", response.data)
 
     def test_rate_article_already_rated(self):
         """
@@ -92,5 +95,6 @@ class TestRatingArticle(ArticlesBaseTest):
             data={"article": {"score": 3}},
             format="json"
         )
+        data = response.data
         self.assertEqual(response.status_code, 200)
-        self.assertIn("article", response.json())
+        self.assertIn("You have already rated the article", data["message"])

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,11 +1,10 @@
 from django.urls import path
 
 from .views import (
-    ArticlesApiView, ArticleDetailApiView,
-    ArticleTagsApiView,
-    ArticleLikeApiView, RateArticleView, ArticleLikeApiView,
-)
-
+        ArticlesApiView, ArticleDetailApiView,
+        ArticleLikeApiView, RateArticleView,
+        FavoriteHandlerView, ArticleTagsApiView
+        )
 urlpatterns = [
     path('articles/', ArticlesApiView.as_view(), name='articles'),
     path(
@@ -24,4 +23,5 @@ urlpatterns = [
         ArticleTagsApiView.as_view(),
         name='article-tags'
     ),
+    path('articles/<slug>/favorite', FavoriteHandlerView.as_view(), name='article-favorite'), 
 ]

--- a/authors/apps/profiles/permissions.py
+++ b/authors/apps/profiles/permissions.py
@@ -1,11 +1,12 @@
 from rest_framework.permissions import BasePermission, SAFE_METHODS
+from rest_framework.response import Response
+from rest_framework import status
 
 
 class IsOwnerOrReadOnly(BasePermission):
     message = 'You are not the owner of this profile.'
 
     def has_permission(self, request, view):
-
         if request.method in SAFE_METHODS:
             return True
         username = view.kwargs.get('username')

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -47,6 +47,7 @@ class ProfileUpdateAPIView(generics.UpdateAPIView):
         return obj
 
 
+
 class ListView(generics.ListAPIView):
     permission_classes = (permissions.IsAuthenticated, )
 


### PR DESCRIPTION
**What does this PR do**
This PR enables a user of the system to favourite an article that they are interested in

**Description of Task to be completed?**

- Enable users to favorite an article
- Enable users to unfavourite an article
- Enables users to see a list of users that have favorited an article

**How should this be manually tested**

- Clone the repo and cd into Ah-backend-aquaman
- git checkout ft-favorite-article-164069228
- pip install -r requirements.txt
- python manage.py makemigrations
- python manage.py migrate
- python manage.py runserver
- Register and then login into the system
- The below endpoint will be used to favorite an article
Favorite an article endpoint
POST  http://127.0.0.1:8000/api/articles/ruby-code/favorite

Unfavorite an article endpoint
DELETE http://127.0.0.1:8000/api/articles/ruby-code/favorite

**Any background context you want to provide?**
N/A

**What are the relevant pivotal tracker stories?**
-  [#164069228](https://www.pivotaltracker.com/story/show/164069228)

**Screenshots**
**Favorite an article**
<img width="1418" alt="Screenshot 2019-03-14 at 20 42 38" src="https://user-images.githubusercontent.com/40163337/54382529-3a1a6c80-46a1-11e9-9220-2eba11308738.png">

**Unfavorite an article**
<img width="1418" alt="Screenshot 2019-03-14 at 20 42 56" src="https://user-images.githubusercontent.com/40163337/54382576-56b6a480-46a1-11e9-93e5-4c9fe7b024d0.png">
