### PR TITLE
fix(create user profile):  Check who is updating a Profile

### DIFF
--- a/authors/apps/authentication/validators.py
+++ b/authors/apps/authentication/validators.py
@@ -8,7 +8,8 @@ from authors.apps.authentication.models import User
 
 def validate_email(email):
     check_email = User.objects.filter(email=email)
-    if not re.search(r'^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$', email):
+    email_regex = r'^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+    if not re.search(email_regex, email):
         raise serializers.ValidationError("Incorrect email format please try again")
     if check_email.exists():
         raise serializers.ValidationError("This email has already been used to create a user")

--- a/authors/apps/profiles/permissions.py
+++ b/authors/apps/profiles/permissions.py
@@ -4,8 +4,9 @@ from rest_framework.permissions import BasePermission, SAFE_METHODS
 class IsOwnerOrReadOnly(BasePermission):
     message = 'You are not the owner of this profile.'
 
-    def has_object_permission(self, request, view, obj):
+    def has_permission(self, request, view):
 
         if request.method in SAFE_METHODS:
             return True
-        return obj.user == request.user
+        username = view.kwargs.get('username')
+        return request.user.username == username


### PR DESCRIPTION
**What does this PR do?**
- This PR ensures that only the user of the profile can update it

**Description of Task to be completed?**
- A user should be able to only update his user profile

**How should this be manually tested?**

- Clone the repo, cd into Ah-backend-aquaman and checkout the branch bg-fix-update-profile-164657442

1. pip install -r requirements.txt
2. python manage.py makemigrations
3. python manage.py migrate
4. python manage.py runserver
5. Register and create an account

- Use this endpoint to update your profile :
PUT http://127.0.0.1:8000/api/profiles/username/edit

**What are the relevant pivotal tracker stories?**

-[ #164657442](https://www.pivotaltracker.com/story/show/164657442)

**Screenshots**

**Updating a profile thats not yours**
<img width="1418" alt="Screenshot 2019-03-15 at 14 55 26" src="https://user-images.githubusercontent.com/40163337/54429744-68945800-4732-11e9-8b45-9271093c435e.png">

**Updating your profile**
<img width="1418" alt="Screenshot 2019-03-15 at 14 59 08" src="https://user-images.githubusercontent.com/40163337/54429920-f2442580-4732-11e9-9a2b-7e3f73fd11bc.png">
