### PR TITLE
#164069235 User should be able to see the time it takes to read an article 

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -4,6 +4,8 @@ from django.contrib.postgres.fields import ArrayField
 from authors.apps.profiles.models import Profile
 from django.contrib.postgres.fields import ArrayField
 
+from authors.settings import WORD_LENGTH, WORD_PER_MINUTE
+
 
 class Article(models.Model):
     title = models.CharField(max_length=100)
@@ -44,6 +46,18 @@ class Article(models.Model):
             for tt in t.values():
                 tag_list.append(tt)
         return tag_list
+
+    @property
+    def read_time(self):
+        """This method calculates the read time of an article"""
+        word_count = 0
+        word_count += len(self.body) / WORD_LENGTH
+        result = int(word_count / WORD_PER_MINUTE)
+        if result >= 1:
+            read_time = str(result) + " minute read"
+        else:
+            read_time = " less than a minute read"
+        return read_time
 
 
 class ArticleLikesDislikes(models.Model):

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -9,6 +9,7 @@ class ArticleSerializer (serializers.ModelSerializer):
     author = ProfileSerializer(read_only=True)
     user_rating = serializers.CharField(
         source="average_rating", required=False)
+    read_time = serializers.CharField(max_length=100, read_only=True)
 
     class Meta:
         model = Article
@@ -25,7 +26,8 @@ class ArticleSerializer (serializers.ModelSerializer):
             "image",
             "likes",
             "dislikes",
-            "user_rating"
+            "user_rating",
+            "read_time",
         )
         read_only_fields = (
             'author',

--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -159,3 +159,21 @@ class TestArticle(ArticlesBaseTest):
         response = self.like_article()
         self.assertEqual(response.data['details']['likes'], False)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieve_all_articles_including_their_readtime(self):
+        """Tests if the articles retrieved include the readtime"""
+        self.add_article()
+        response = self.client.get(self.articles_url)
+        self.assertIn('read_time', response.data['articles'][0])
+        self.assertIn('minute', response.data['articles'][0]['read_time'])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieve_single_article_including_the_readtime(self):
+        """Tests if an article retrieved includes the readtime"""
+        self.add_article()
+        article = Article.objects.all().first()
+        response = self.client.get(reverse('articles:article-detail',
+                                           kwargs={'slug': article.slug}))
+        self.assertIn('read_time', response.data)
+        self.assertIn('minute', response.data['read_time'])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -171,3 +171,12 @@ EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
 
 
 django_heroku.settings(locals())
+
+
+# Reading time configurations
+
+# Number of words read per minute
+WORD_PER_MINUTE = 265
+
+# Standard number of characters in a word
+WORD_LENGTH = 5


### PR DESCRIPTION
## What does this PR do?
This PR adds a feature that enables a user to see the time it takes to read an article.

## How should this be manually tested?

- Clone this repository
- cd into the directory Ah-backend-aquaman
- Checkout the branch ft-article-read-time-164069235
- Create and activate your virtual environment
- pip install -r requirements.txt
- python manage.py makemmigrations
- python manage.py migrate
- Source your .env file
- python manage.py runserver
- Sign up, verify your email and login
- Then navigate to the endpoint http://127.0.0.1:8000/api/articles/ and post an article
- Thereafter using the same endpoint http://127.0.0.1:8000/api/articles/ get back the articles
- You will be able to see the readtime associated with that article

## What are the relevant pivotal tracker stories?

[#164069235](https://www.pivotaltracker.com/story/show/164069235)

## Screenshots

After creating your account, verifying your account and logging in, copy the token and paste it into the token field

![image](https://user-images.githubusercontent.com/42435346/54342175-d9f9db00-464c-11e9-85c0-6526a338ecc6.png)

Then proceed to the articles endpoint and post an article

![image](https://user-images.githubusercontent.com/42435346/54512841-92ce5b80-4966-11e9-883a-14357b4da149.png)

When you get back the articles, you are able to see the time it takes to read that article

![image](https://user-images.githubusercontent.com/42435346/54512915-d032e900-4966-11e9-86d9-0006deffa72f.png)



