### PR TITLE
#164689524 Fix for reset password glitch

### DIFF
--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -124,7 +124,7 @@ class PasswordResetAPIView(generics.GenericAPIView):
             get_object_or_404(User, email=request.data['email'])
             message = [
                 request,
-                "reset-password/change",
+                "reset-password/change/",
                 str((jwt.encode({"email": request.data['email']}, 
                     settings.SECRET_KEY)).decode('utf-8')
                 ),
@@ -147,7 +147,7 @@ class PasswordResetAPIView(generics.GenericAPIView):
 
 class ChangePasswordAPIView(generics.GenericAPIView):
     # Allow any user (authenticated or not) to hit this endpoint.
-    #then allows users to set password
+    # then allows users to set password
     permission_classes = (AllowAny,)
 
     def patch(self, request):


### PR DESCRIPTION
#### What does this PR do?
- This PR enables a user to reset their password
#### Description of Task to be completed?
- Send a reset password link via email
- Enable a user to reset password
#### How should this be manually tested?
- Make sure PostgreSQL is installed and create a database.
- Clone the repo, cd into `Ah-backend-aquaman` and checkout the branch `ft-reset-password-164069219`
    -  pip install -r requirements.txt
    -  python manage.py makemmigrations
    -  python manage.py migrate
    -  python manage.py runserver
- Use these endpoints to reset password:
    -  Password Link
       `http://127.0.0.1:8000/api/users/reset-password/`
        Then check your email for reset password link
    -  Password Change
       `http://127.0.0.1:8000/api/users/reset-password/change/`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- [#164069219](https://www.pivotaltracker.com/story/show/164069219)

#### Screen shots

* The user navigates to the `http://127.0.0.1:8000/api/users/reset-password/` and sends a valid email

<img width="1144" alt="Screenshot 2019-03-11 at 12 43 12" src="https://user-images.githubusercontent.com/19649761/54115255-31097100-43fd-11e9-982e-5185eeab3b46.png">

* The user goes to email and clicks on reset password link

<img width="1144" alt="Screenshot 2019-03-11 at 12 46 01" src="https://user-images.githubusercontent.com/19649761/54115363-572f1100-43fd-11e9-9a9c-8cf04dd73b1f.png">

* The user follows that link and then he/she provides their password

<img width="1144" alt="Screenshot 2019-03-11 at 12 44 15" src="https://user-images.githubusercontent.com/19649761/54115439-7c238400-43fd-11e9-854a-33f976b64a80.png">

