### PR TITLE
#164824176 fix edit history feature

### DIFF
--- a/authors/apps/comments/tests/test_comment_history.py
+++ b/authors/apps/comments/tests/test_comment_history.py
@@ -29,7 +29,7 @@ class TestComment(BaseTestCase):
         res = self.client.post(url, data=comment, format="json")
         data = res.data
         comment_id = data["comment"]["id"]
-        fetch_url = reverse("comments:comment_history", kwargs={'slug':slug,'pk':comment_id})
+        fetch_url = reverse("comments:comment_history", kwargs={'pk':comment_id})
         response = self.client.get(fetch_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(comment["body"], 
@@ -49,7 +49,7 @@ class TestComment(BaseTestCase):
         comment_id = data["comment"]["id"]
         update_url = reverse("comments:single_comment", kwargs={"slug":slug, "pk":comment_id})
         self.client.put(update_url, data=update_comment, format="json")
-        fetch_url = reverse("comments:comment_history", kwargs={'slug':slug,'pk':comment_id})
+        fetch_url = reverse("comments:comment_history", kwargs={'pk':comment_id})
         response = self.client.get(fetch_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(update_comment["body"],
@@ -67,7 +67,7 @@ class TestComment(BaseTestCase):
         res = self.client.post(url, data=comment, format="json")
         data = res.data
         comment_id = data["comment"]["id"]
-        fetch_url = reverse("comments:comment_history", kwargs={'slug':slug,'pk':comment_id})
+        fetch_url = reverse("comments:comment_history", kwargs={'pk':comment_id})
         self.user_access2()
         response = self.client.get(fetch_url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -83,7 +83,7 @@ class TestComment(BaseTestCase):
         slug = self.article_slug()
         url = reverse("comments:post_comment", kwargs={'slug': slug})
         self.client.post(url, data=comment, format="json")
-        fetch_url = reverse("comments:comment_history", kwargs={'slug':slug,'pk':4})
+        fetch_url = reverse("comments:comment_history", kwargs={'pk':4})
         response = self.client.get(fetch_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("Not found", response.data["detail"])

--- a/authors/apps/comments/tests/test_like_comment.py
+++ b/authors/apps/comments/tests/test_like_comment.py
@@ -27,7 +27,7 @@ class TestComment(BaseTestCase):
         res = self.client.post(url, data=comment, format="json")
         data = res.data
         comment_id = data["comment"]["id"]
-        fetch_url = reverse("comments:comment-like", kwargs={"slug":slug, "pk":comment_id})
+        fetch_url = reverse("comments:comment-like", kwargs={"pk":comment_id})
         response = self.client.put(fetch_url)
         data = response.data
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -44,7 +44,7 @@ class TestComment(BaseTestCase):
         res = self.client.post(url, data=comment, format="json")
         data = res.data
         comment_id = data["comment"]["id"]
-        fetch_url = reverse("comments:comment-like", kwargs={"slug":slug, "pk":comment_id})
+        fetch_url = reverse("comments:comment-like", kwargs={"pk":comment_id})
         self.client.put(fetch_url)
         response = self.client.put(fetch_url)
         data = response.data
@@ -62,7 +62,7 @@ class TestComment(BaseTestCase):
         res = self.client.post(url, data=comment, format="json")
         data = res.data
         comment_id = data["comment"]["id"]
-        fetch_url = reverse("comments:comment-like", kwargs={"slug":slug, "pk":comment_id})
+        fetch_url = reverse("comments:comment-like", kwargs={"pk":comment_id})
         self.client.put(fetch_url)
         response = self.client.get(fetch_url)
         data = response.data
@@ -80,7 +80,7 @@ class TestComment(BaseTestCase):
         res = self.client.post(url, data=comment, format="json")
         data = res.data
         comment_id = data["comment"]["id"]
-        fetch_url = reverse("comments:comment-like", kwargs={"slug":slug, "pk":comment_id})
+        fetch_url = reverse("comments:comment-like", kwargs={"pk":comment_id})
         self.client.put(fetch_url)
         response = self.client.delete(fetch_url)
         data = response.data
@@ -98,7 +98,7 @@ class TestComment(BaseTestCase):
         res = self.client.post(url, data=comment, format="json")
         data = res.data
         comment_id = data["comment"]["id"]
-        fetch_url = reverse("comments:comment-like", kwargs={"slug":slug, "pk":comment_id})
+        fetch_url = reverse("comments:comment-like", kwargs={"pk":comment_id})
         response = self.client.delete(fetch_url)
         data = response.data
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/authors/apps/comments/urls.py
+++ b/authors/apps/comments/urls.py
@@ -14,11 +14,11 @@ urlpatterns = [
         CommentsAPIView.as_view(),
         name='single_comment'),
     path(
-        '<slug>/comments/<int:pk>/like/',
+        'comments/<int:pk>/like/',
          CommentLikeView.as_view(),
          name='comment-like'),
     path(
-        '<slug>/comments/<int:pk>/history',
+        'comments/<int:pk>/history',
         CommentEditHistoryAPIView.as_view(),
         name='comment_history'),
     

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -182,7 +182,7 @@ class CommentEditHistoryAPIView(generics.GenericAPIView):
     """
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request, slug, pk):
+    def get(self, request, pk):
         comment = get_object_or_404(Comment, id=pk)
         comment_history = comment.comment_history.all()
         edit_history = []

--- a/authors/apps/profiles/tests/test_follow.py
+++ b/authors/apps/profiles/tests/test_follow.py
@@ -47,7 +47,7 @@ class FollowUsersTests(BaseTestCase):
                       'username': new_user_2['username']})
         self.client.post(url, format='json')
         response = self.client.delete(url, format='json')
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('You have successfully unfollowed ' +
                       str(new_user_2['username']), str(response.data))
 

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -122,7 +122,7 @@ class FollowsView(generics.CreateAPIView, generics.DestroyAPIView):
         return Response(
             {'message': 'You have successfully unfollowed {}.'.format(
                 username)},
-            status=status.HTTP_204_NO_CONTENT)
+            status=status.HTTP_200_OK)
 
     def get(self, request, username):
         """


### PR DESCRIPTION
**What does this PR do?**
This PR fixes a bug in comment edit history feature removing the article slug from the url

**Description of Task to be completed?**

- Remove article slug from the edit comment feature
- Change status code in follow user endpoint to a 200_OK

**How should this be manually tested?**

- Clone the repo and cd into Ah-backend-aquaman
- git checkout bg-fix-edit-history-164824176
- pip install -r requirements.txt
- python manage.py makemigrations
- python manage.py migrate
- python manage.py runserver
- Register and then login into the system
- The below endpoint will be used

     Get edit history of comment
     GET http://127.0.0.1:8000/api/comments/1/history

**Any background context you want to provide?**
N/A

**What are the relevant pivotal tracker stories?**

- [#164824176](https://www.pivotaltracker.com/story/show/164824176)