### PR TITLE
#164847589 fix article view feature

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -64,7 +64,7 @@ class ArticleSerializer (serializers.ModelSerializer):
         comments = Comment.objects.filter(article=obj)
         comment_data = []
         for comment in comments:
-            comment_data.append(comment.body)
+            comment_data.append({"comment":comment.body, "author":comment.commented_by.user.username})
         return comment_data
 
 

--- a/authors/apps/comments/serializers.py
+++ b/authors/apps/comments/serializers.py
@@ -7,6 +7,7 @@ class CommentSerializer(serializers.ModelSerializer):
 
     author = ProfileSerializer(read_only=True)
     commented_by = ProfileSerializer(read_only=True)
+    like_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
@@ -20,15 +21,19 @@ class CommentSerializer(serializers.ModelSerializer):
             "id",
             "first_highlited",
             "last_highlited",
-            "highlighted_text"
+            "highlighted_text",
+            "like_count"
         )
         read_only_fields = (
             "article",
             "author",
             "created_at",
             "updated_at",
-            "id"
+            "id",
+            "like_count"
         )
+    def get_like_count(self,obj):
+        return CommentLike.objects.filter(comment=obj).count()
 
 class CommentLikeSerializer(serializers.ModelSerializer):
     liked_by = ProfileSerializer(read_only=True)


### PR DESCRIPTION
**What does this PR do?**
This PR fixes article view to show comment and who authored it as well as show like count on a comment

**Description of Task to be completed?**

- Ensure that user can view comments on an article and the author of the comment
- Ensure on each comment we provide a count of the likes it has received

**How should this be manually tested?**

- Clone the repo and cd into Ah-backend-aquaman
- git checkout bg-fix-edit-history-164824176
- pip install -r requirements.txt
- python manage.py makemigrations
- python manage.py migrate
- python manage.py runserver
- Register and then login into the system
- The below endpoint will be used

      Get an article
      GET http://127.0.0.1:8000/api/articles/articleslug

      Get a comment
      GET http://127.0.0.1:8000/api/articleslug/comments/commentID

**Any background context you want to provide?**
N/A

**What are the relevant pivotal tracker stories?**

- [#164847589](https://www.pivotaltracker.com/story/show/164847589)