### PR TITLE
#165208888 fix reset password implementation

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -258,7 +258,7 @@ class ReportArticleView(generics.GenericAPIView):
         data = {"subject": "[Article Reported]", "to":
                 serializer.data['article']['author']['email'],
                 "body": f"Your article was reported,These are the details:\n{data['reason']}"}
-        Utilities.send_email(data, 'article_reports')
+        Utilities.send_email(data,None,'article_reports')
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/authors/apps/authentication/tests/test_reset_password.py
+++ b/authors/apps/authentication/tests/test_reset_password.py
@@ -104,4 +104,4 @@ class ResetPasswordTest(BaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['errors']
-                         [0], "Password feild is required.")
+                         [0], "Password field is required.")

--- a/authors/apps/core/utils.py
+++ b/authors/apps/core/utils.py
@@ -6,10 +6,18 @@ class Utilities:
     """Utility class that contains helper function"""
 
     @staticmethod
-    def send_email(data,intent=None):
+    def send_email(data,domain=None,intent=None):
         """This function sends email to users."""
         if intent == 'article_reports':
             EmailMessage(data['subject'],body=data['body'],to=[data['to']]).send(fail_silently=False)
+
+        elif intent=='password_rest':
+            url = f"{domain}/reset_password/{data[2]}"
+            subject = f"[Authors Heaven] {data[3]}"
+            body = f"Hello, \
+                               \nYou are receiving this e-mail because you have {data[4]}' \
+                               '\nClick the click below to verify your account.\n{url}"
+            EmailMessage(subject, body, to=[data[5]]).send(fail_silently=False)
         else:
             url = f"http://{get_current_site(data[0]).domain}/api/users/{data[1]}?token={data[2]}"
             subject = f"[Authors Heaven] {data[3]}"


### PR DESCRIPTION
#### What does this PR do?
- This PR fixes the implementation of the reset password feature

#### Description of Task to be completed?
- Send a reset password link via email
- Enable a user to reset their password

#### How should this be manually tested?
- Make sure PostgreSQL is installed and create a database.
- Clone the repo, cd into `Ah-backend-aquaman` and checkout the branch `bg-fix-password-reset-165208888`
    -  pip install -r requirements.txt
    -  python manage.py makemmigrations
    -  python manage.py migrate
    -  python manage.py runserver
- Navigate to the endpoints to reset your password:
    -  Password Link
       `http://127.0.0.1:8000/api/users/reset-password/`
        Then check your email for reset password link
    -  Password Change
       `http://127.0.0.1:8000/api/users/reset-password/change/`

#### What are the relevant pivotal tracker stories?
[#165208888](https://www.pivotaltracker.com/story/show/165208888)


