### PR TITLE
#165114722 add heroku link to CORS

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -136,6 +136,9 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:4000',
     'localhost:3000',
     'localhost:8080',
+    'https://ah-aquaman-frontend-staging.herokuapp.com/',
+    'https://ah-aquaman-frontend-stagi-pr-9.herokuapp.com/',
+
 )
 
 # Tell Django about the custom `User` model we created. The string


### PR DESCRIPTION
**What does this PR do?**
This PR makes changes to CORS whitelist to enable us to make requests to our server.

**Description of Task to be completed?**

- Add the route we are using to the CORS whitelist in our settings file

**How should this be manually tested?**

- Try to make a request to our server from the routes specified. Use the following link https://ah-backend-aquaman-staging.herokuapp.com

**Any background context you want to provide?**
N/A

**What are the relevant pivotal tracker stories?**

- [#165114722](https://www.pivotaltracker.com/story/show/165114722)