### PR TITLE
 #165590803 Users  should see correct details of their followers

### DIFF
--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -162,8 +162,8 @@ class FollowersView(generics.ListAPIView):
             user = User.objects.get(id=follow['follower'])
             followers_list.append({
                 "username": user.username,
-                "bio": profile.bio,
-                "image": profile.image,
+                "bio": user.profile.bio,
+                "image": user.profile.image,
                 "followed_at": follow['followed_at']
             })
         if not followers_list:


### PR DESCRIPTION
#### What does this PR do?
- Enable users to view correct details of the followers

#### Description of Task to be completed?
- Modify response to return user profile data

#### How should this be manually tested?
- Clone the [repo](https://github.com/andela/Ah-backend-aquaman), cd into `Ah-backend-aquaman` and checkout the branch `bg-fix-followers-list-165590803`
    -  pip install -r requirements.txt
    -  python manage.py migrate
    -  python manage.py runserver
    - Follow some user using two different accounts
   - Then list their followers

#### What are the relevant pivotal tracker stories?
- [#165590803](https://www.pivotaltracker.com/story/show/165590803)

#### Screenshots (if appropriate)
> Before
<img width="1146" alt="Screenshot 2019-04-25 at 08 38 26" src="https://user-images.githubusercontent.com/20795487/56713151-9dd09480-6739-11e9-977a-d779ffb66fa5.png">

> After
<img width="1141" alt="Screenshot 2019-04-25 at 08 38 54" src="https://user-images.githubusercontent.com/20795487/56713158-a628cf80-6739-11e9-9d57-a541cf3a9962.png">

